### PR TITLE
Add game encounters and version exclusives commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -245,6 +245,24 @@ pub enum GameCommands {
         /// Game name (e.g. scarlet, sword, lets-go-pikachu)
         game: String,
     },
+    /// List all Pokémon encounterable in a game
+    Encounters {
+        /// Game name
+        game: String,
+        #[arg(long, default_value = "50")]
+        limit: u64,
+        #[arg(long, default_value = "0")]
+        offset: u64,
+    },
+    /// Show version-exclusive Pokémon for a game
+    Exclusives {
+        /// Game name
+        game: String,
+        #[arg(long, default_value = "50")]
+        limit: u64,
+        #[arg(long, default_value = "0")]
+        offset: u64,
+    },
 }
 
 // -- Collection subcommands --

--- a/src/commands/game.rs
+++ b/src/commands/game.rs
@@ -4,6 +4,7 @@ use rusqlite::Connection;
 use crate::db::queries;
 use crate::output::*;
 use strsim;
+use super::{validate_game_filter, validate_limit};
 
 pub fn list(conn: &Connection, home_compatible: bool, format: &OutputFormat) -> Result<()> {
     let games = queries::list_games(conn, home_compatible)?;
@@ -64,6 +65,8 @@ pub fn show(conn: &Connection, game: &str, format: &OutputFormat) -> Result<()> 
 
     if let Some(info) = game_info {
         let actions = vec![
+            Action::new("encounters", &format!("pokedex game encounters {game_name}")),
+            Action::new("exclusives", &format!("pokedex game exclusives {game_name}")),
             Action::new("collection_for_game", &format!("pokedex collection list --game={game_name}")),
             Action::new("all_games", "pokedex game list"),
         ];
@@ -72,4 +75,76 @@ pub fn show(conn: &Connection, game: &str, format: &OutputFormat) -> Result<()> 
     }
 
     Ok(())
+}
+
+pub fn encounters(conn: &Connection, game: &str, limit: u64, offset: u64, format: &OutputFormat) -> Result<()> {
+    validate_game_filter(conn, game, "pokedex game encounters")?;
+    let limit = validate_limit(limit)?;
+
+    let (entries, total) = queries::get_game_encounters(conn, game, limit, offset)?;
+
+    if entries.is_empty() && total == 0 {
+        ErrorResponse::not_found(
+            &format!("No encounter data found for game '{game}'"),
+            vec![
+                Action::new("game_list", "pokedex game list"),
+                Action::new("discover", "pokedex --discover"),
+            ],
+        ).print()?;
+        return Ok(());
+    }
+
+    let cmd = format!("pokedex game encounters {game}");
+    let mut actions = vec![
+        Action::new("show", "pokedex pokemon show {name}"),
+        Action::new("encounters", &format!("pokedex pokemon encounters {{name}} --game={game}")),
+        Action::new("exclusives", &format!("pokedex game exclusives {game}")),
+    ];
+    if offset + limit < total {
+        actions.push(Action::new("next_page", &format!("{cmd} --limit={limit} --offset={}", offset + limit)));
+    }
+    if offset > 0 {
+        let prev_offset = offset.saturating_sub(limit);
+        actions.push(Action::new("prev_page", &format!("{cmd} --limit={limit} --offset={prev_offset}")));
+    }
+
+    let response = Response::new(entries, actions, Meta::paginated(&cmd, total, limit, offset));
+    response.print(format)
+}
+
+pub fn exclusives(conn: &Connection, game: &str, limit: u64, offset: u64, format: &OutputFormat) -> Result<()> {
+    validate_game_filter(conn, game, "pokedex game exclusives")?;
+    let limit = validate_limit(limit)?;
+
+    let (entries, total, paired) = queries::get_game_exclusives(conn, game, limit, offset)?;
+
+    if paired.is_none() {
+        ErrorResponse::not_found(
+            &format!("'{game}' has no paired version — it's a standalone game, so there are no version exclusives"),
+            vec![
+                Action::new("encounters", &format!("pokedex game encounters {game}")),
+                Action::new("game_list", "pokedex game list"),
+            ],
+        ).print()?;
+        return Ok(());
+    }
+
+    let paired_name = paired.unwrap();
+    let cmd = format!("pokedex game exclusives {game}");
+    let mut actions = vec![
+        Action::new("show", "pokedex pokemon show {name}"),
+        Action::new("encounters", &format!("pokedex pokemon encounters {{name}} --game={game}")),
+        Action::new("other_version", &format!("pokedex game exclusives {paired_name}")),
+        Action::new("all_encounters", &format!("pokedex game encounters {game}")),
+    ];
+    if offset + limit < total {
+        actions.push(Action::new("next_page", &format!("{cmd} --limit={limit} --offset={}", offset + limit)));
+    }
+    if offset > 0 {
+        let prev_offset = offset.saturating_sub(limit);
+        actions.push(Action::new("prev_page", &format!("{cmd} --limit={limit} --offset={prev_offset}")));
+    }
+
+    let response = Response::new(entries, actions, Meta::paginated(&cmd, total, limit, offset));
+    response.print(format)
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -450,3 +450,12 @@ pub struct ItemHolder {
     pub game: String,
     pub game_slug: String,
 }
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GameEncounterSummary {
+    pub species_id: i64,
+    pub name: String,
+    pub display_name: String,
+    pub encounter_count: i64,
+    pub methods: Vec<String>,
+}

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -2207,3 +2207,122 @@ pub fn get_item(conn: &Connection, item_id: i64, game_filter: Option<&str>) -> R
         held_by,
     })
 }
+
+// ---- Game encounter queries ----
+
+pub fn get_game_encounters(conn: &Connection, game: &str, limit: u64, offset: u64) -> Result<(Vec<GameEncounterSummary>, u64)> {
+    let total: u64 = conn.query_row(
+        "SELECT COUNT(DISTINCT s.id) \
+         FROM encounters e \
+         JOIN versions v ON v.id = e.version_id \
+         JOIN pokemon p ON p.id = e.pokemon_id AND p.is_default = 1 \
+         JOIN species s ON s.id = p.species_id \
+         WHERE LOWER(v.name) = LOWER(?1)",
+        params![game],
+        |row| row.get::<_, i64>(0),
+    )? as u64;
+
+    let mut stmt = conn.prepare(
+        "SELECT s.id, s.name, COALESCE(sn.name, s.name), \
+         COUNT(DISTINCT e.location_area_id), \
+         GROUP_CONCAT(DISTINCT COALESCE(emn.name, em.name)) \
+         FROM encounters e \
+         JOIN versions v ON v.id = e.version_id \
+         JOIN pokemon p ON p.id = e.pokemon_id AND p.is_default = 1 \
+         JOIN species s ON s.id = p.species_id \
+         LEFT JOIN species_names sn ON sn.species_id = s.id \
+         JOIN encounter_slots es ON es.id = e.encounter_slot_id \
+         JOIN encounter_methods em ON em.id = es.encounter_method_id \
+         LEFT JOIN encounter_method_names emn ON emn.encounter_method_id = em.id \
+         WHERE LOWER(v.name) = LOWER(?1) \
+         GROUP BY s.id \
+         ORDER BY s.id \
+         LIMIT ?2 OFFSET ?3"
+    )?;
+
+    let rows: Vec<GameEncounterSummary> = stmt.query_map(params![game, limit, offset], |row| {
+        let methods_str: String = row.get::<_, String>(4).unwrap_or_default();
+        let methods: Vec<String> = methods_str.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+        Ok(GameEncounterSummary {
+            species_id: row.get(0)?,
+            name: row.get(1)?,
+            display_name: row.get(2)?,
+            encounter_count: row.get(3)?,
+            methods,
+        })
+    })?.filter_map(|r| r.ok()).collect();
+
+    Ok((rows, total))
+}
+
+pub fn get_game_exclusives(conn: &Connection, game: &str, limit: u64, offset: u64) -> Result<(Vec<GameEncounterSummary>, u64, Option<String>)> {
+    // Find the paired version(s) via version_group_id
+    let paired: Vec<String> = conn.prepare(
+        "SELECT v2.name FROM versions v1 \
+         JOIN versions v2 ON v2.version_group_id = v1.version_group_id AND v2.name != v1.name \
+         WHERE LOWER(v1.name) = LOWER(?1)"
+    )?.query_map(params![game], |row| row.get(0))?.filter_map(|r| r.ok()).collect();
+
+    if paired.is_empty() {
+        return Ok((Vec::new(), 0, None));
+    }
+
+    let paired_name: String = paired[0].clone();
+
+    let total: u64 = conn.query_row(
+        "SELECT COUNT(DISTINCT s.id) \
+         FROM encounters e \
+         JOIN versions v ON v.id = e.version_id \
+         JOIN pokemon p ON p.id = e.pokemon_id AND p.is_default = 1 \
+         JOIN species s ON s.id = p.species_id \
+         WHERE LOWER(v.name) = LOWER(?1) \
+         AND s.id NOT IN ( \
+             SELECT DISTINCT s2.id FROM encounters e2 \
+             JOIN versions v2 ON v2.id = e2.version_id \
+             JOIN pokemon p2 ON p2.id = e2.pokemon_id AND p2.is_default = 1 \
+             JOIN species s2 ON s2.id = p2.species_id \
+             WHERE LOWER(v2.name) = LOWER(?2) \
+         )",
+        params![game, paired_name],
+        |row| row.get::<_, i64>(0),
+    )? as u64;
+
+    let mut stmt = conn.prepare(
+        "SELECT s.id, s.name, COALESCE(sn.name, s.name), \
+         COUNT(DISTINCT e.location_area_id), \
+         GROUP_CONCAT(DISTINCT COALESCE(emn.name, em.name)) \
+         FROM encounters e \
+         JOIN versions v ON v.id = e.version_id \
+         JOIN pokemon p ON p.id = e.pokemon_id AND p.is_default = 1 \
+         JOIN species s ON s.id = p.species_id \
+         LEFT JOIN species_names sn ON sn.species_id = s.id \
+         JOIN encounter_slots es ON es.id = e.encounter_slot_id \
+         JOIN encounter_methods em ON em.id = es.encounter_method_id \
+         LEFT JOIN encounter_method_names emn ON emn.encounter_method_id = em.id \
+         WHERE LOWER(v.name) = LOWER(?1) \
+         AND s.id NOT IN ( \
+             SELECT DISTINCT s2.id FROM encounters e2 \
+             JOIN versions v2 ON v2.id = e2.version_id \
+             JOIN pokemon p2 ON p2.id = e2.pokemon_id AND p2.is_default = 1 \
+             JOIN species s2 ON s2.id = p2.species_id \
+             WHERE LOWER(v2.name) = LOWER(?2) \
+         ) \
+         GROUP BY s.id \
+         ORDER BY s.id \
+         LIMIT ?3 OFFSET ?4"
+    )?;
+
+    let rows: Vec<GameEncounterSummary> = stmt.query_map(params![game, paired_name, limit, offset], |row| {
+        let methods_str: String = row.get::<_, String>(4).unwrap_or_default();
+        let methods: Vec<String> = methods_str.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+        Ok(GameEncounterSummary {
+            species_id: row.get(0)?,
+            name: row.get(1)?,
+            display_name: row.get(2)?,
+            encounter_count: row.get(3)?,
+            methods,
+        })
+    })?.filter_map(|r| r.ok()).collect();
+
+    Ok((rows, total, Some(paired_name)))
+}

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -178,6 +178,24 @@ pub fn print_discovery() -> anyhow::Result<()> {
                         description: "Show details for a game".to_string(),
                         flags: vec![],
                     },
+                    CommandInfo {
+                        name: "encounters".to_string(),
+                        usage: "pokedex game encounters <game> [--limit=N] [--offset=N]".to_string(),
+                        description: "List all Pokémon encounterable in a game".to_string(),
+                        flags: vec![
+                            FlagInfo { flag: "--limit".to_string(), description: "Results per page".to_string(), default: Some("50".to_string()) },
+                            FlagInfo { flag: "--offset".to_string(), description: "Skip N results".to_string(), default: Some("0".to_string()) },
+                        ],
+                    },
+                    CommandInfo {
+                        name: "exclusives".to_string(),
+                        usage: "pokedex game exclusives <game> [--limit=N] [--offset=N]".to_string(),
+                        description: "Show version-exclusive Pokémon for a game".to_string(),
+                        flags: vec![
+                            FlagInfo { flag: "--limit".to_string(), description: "Results per page".to_string(), default: Some("50".to_string()) },
+                            FlagInfo { flag: "--offset".to_string(), description: "Skip N results".to_string(), default: Some("0".to_string()) },
+                        ],
+                    },
                 ],
             },
             Resource {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,12 @@ pub fn dispatch(command: Option<cli::Commands>, format: &OutputFormat, conn: &mu
                 cli::GameCommands::Show { game } => {
                     commands::game::show(conn, &game, format)?;
                 }
+                cli::GameCommands::Encounters { game, limit, offset } => {
+                    commands::game::encounters(conn, &game, limit, offset, format)?;
+                }
+                cli::GameCommands::Exclusives { game, limit, offset } => {
+                    commands::game::exclusives(conn, &game, limit, offset, format)?;
+                }
             }
         }
         cli::Commands::Collection { command: col_cmd } => {

--- a/tests/screenplays/ge_game_encounters_and__20260401_042630.yaml
+++ b/tests/screenplays/ge_game_encounters_and__20260401_042630.yaml
@@ -1,0 +1,45 @@
+name: Game Encounters and Exclusives
+persona: GE
+description: Verify game encounters listing and version exclusive comparison
+needs_seed: true
+mutates_collection: false
+
+steps:
+  - name: Violet encounters returns species list
+    command: pokedex game encounters violet --limit=5
+    assert:
+      exit_code: 0
+      has_fields: ["data[0].species_id", "data[0].name", "data[0].display_name", "data[0].encounter_count", "data[0].methods"]
+      array_len: {data: {min: 5, max: 5}}
+      type_of: {meta.total: number}
+
+  - name: Red encounters works for Gen 1
+    command: pokedex game encounters red --limit=3
+    assert:
+      exit_code: 0
+      array_len: {data: {min: 1}}
+
+  - name: Violet exclusives includes Miraidon
+    command: pokedex game exclusives violet
+    assert:
+      exit_code: 0
+      contains: {data: Miraidon}
+      type_of: {meta.total: number}
+
+  - name: Exclusives has other_version action
+    command: pokedex game exclusives violet
+    assert:
+      exit_code: 0
+      contains: {actions: pokedex game exclusives scarlet}
+
+  - name: Invalid game returns error
+    command: pokedex game encounters fakegame
+    assert:
+      exit_code: 1
+      equals: {error.code: NOT_FOUND}
+
+  - name: Game show now has encounters action
+    command: pokedex game show violet
+    assert:
+      exit_code: 0
+      contains: {actions: pokedex game encounters violet}


### PR DESCRIPTION
## Summary
Two new commands that close the HATEOAS navigation gap from games to their encounter pools:
- `pokedex game encounters <game>` — lists all encounterable species with location counts and methods
- `pokedex game exclusives <game>` — shows version-exclusive Pokémon by diffing against the paired version

This was the original issue that started this work — answering "what are the version exclusives in Violet?" now takes one command instead of querying the DB directly.

Closes #1

## Changes
- `src/cli.rs` — added `Encounters` and `Exclusives` variants to `GameCommands`
- `src/commands/game.rs` — added `encounters()` and `exclusives()` handlers; added encounters/exclusives action links to `game show`
- `src/db/models.rs` — added `GameEncounterSummary` struct
- `src/db/queries.rs` — added `get_game_encounters()` and `get_game_exclusives()` query functions using version_group pairing
- `src/lib.rs` — added dispatch for both new commands
- `src/discover.rs` — registered both commands in game resource
- 6-step screenplay testing encounters, exclusives, Gen 1 compatibility, action links, and error handling

## Test plan
- All 39 seed pipeline tests pass
- All 78 encounter validation tests pass
- All 2200+ screenplay steps pass (including 6 new)
- `cargo clippy` clean
- Manual verification: `game encounters violet` returns 594 species; `game exclusives violet` returns 26 exclusives including Miraidon

🤖 Generated with [Claude Code](https://claude.com/claude-code)